### PR TITLE
ERC721AntiScamにlocalAllowedAddressesを追加し、CALを変更できるように修正

### DIFF
--- a/contracts/ERC721AntiScam/ERC721AntiScam.sol
+++ b/contracts/ERC721AntiScam/ERC721AntiScam.sol
@@ -37,16 +37,22 @@ abstract contract ERC721AntiScam is ERC721A, IERC721AntiScam, Ownable {
         _lockStatus[id] = level;
     }
 
-    function getLocked(address to, uint256 tokenId) public virtual view returns(bool) {
+    function getLocked(address to, uint256 tokenId) public virtual view returns(bool isLocked) {
         LockStatus status = contractLockStatus;
         if (uint(_lockStatus[tokenId]) >= 1) {
             status = _lockStatus[tokenId];
         }
 
-        return _getLocked(to, status);
+        if (status == LockStatus.CalLock) {
+            if (ownerOf(tokenId) == msg.sender) {
+                return false;
+            }
+        } else {
+            return _getLocked(to, status);
+        }
     }
     
-    function _getLocked(address to, LockStatus status) internal virtual view returns(bool){
+    function _getLocked(address to, LockStatus status) internal virtual view returns(bool isLocked){
         if (status == LockStatus.UnLock) {
             return false;
         } else if (status == LockStatus.AllLock)  {

--- a/contracts/ERC721AntiScam/IERC721AntiScam.sol
+++ b/contracts/ERC721AntiScam/IERC721AntiScam.sol
@@ -31,9 +31,14 @@ interface IERC721AntiScam {
 
 
     /**
-     * @dev CALのリストに無い独自の許可アドレスを設定する場合、こちらに許可アドレスを記載する。
+     * @dev CALのリストに無い独自の許可アドレスを追加する場合、こちらにアドレスを記載する。
      */
-    function setLocalContractAllowList(address _contract, bool _state) external;
+    function addLocalContractAllowList(address _contract) external;
+
+    /**
+     * @dev CALのリストにある独自の許可アドレスを削除する場合、こちらにアドレスを記載する。
+     */
+    function removeLocalContractAllowList(address _contract) external;
 
 
     /**

--- a/contracts/test/MarketDummy.sol
+++ b/contracts/test/MarketDummy.sol
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.7.0 <0.9.0;
+
+import "../ERC721AntiScam/ERC721AntiScam.sol";
+import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+
+contract MarketDummy {
+    constructor() {
+    }
+
+    function callIsApprovedForAll(address target, address owner, address operator) public view returns (bool) {
+        IERC721 targetContract = IERC721(target);
+        return targetContract.isApprovedForAll(owner, operator);
+    }
+
+    function callSetApprovalForAll(address target, address operator, bool approved) public {
+        IERC721 targetContract = IERC721(target);
+        targetContract.setApprovalForAll(operator, approved);
+    }
+
+    function callApprove(address target, address to, uint256 tokenId) public {
+        IERC721 targetContract = IERC721(target);
+        targetContract.approve(to, tokenId);
+    }
+
+    function callSafeTransferFrom(
+        address target,
+        address from,
+        address to,
+        uint256 tokenId
+    ) public {
+        IERC721 targetContract = IERC721(target);
+        targetContract.safeTransferFrom(from, to, tokenId);
+    }
+
+    function callSafeTransferFrom(
+        address target,
+        address from,
+        address to,
+        uint256 tokenId,
+        bytes memory _data
+    ) public {
+        IERC721 targetContract = IERC721(target);
+        targetContract.safeTransferFrom(from, to, tokenId, _data);
+    }
+
+    function callTransferFrom(
+        address target,
+        address from,
+        address to,
+        uint256 tokenId
+    ) public {
+        IERC721 targetContract = IERC721(target);
+        targetContract.transferFrom(from, to, tokenId);
+    }
+
+}

--- a/mock/ERC721AntiScam.ts
+++ b/mock/ERC721AntiScam.ts
@@ -1,3 +1,4 @@
+import { addressToBuffer } from "@nomicfoundation/ethereumjs-evm/dist/opcodes";
 import { loadFixture, time, mine } from "@nomicfoundation/hardhat-network-helpers";
 import { expect } from "chai";
 import { ethers } from "hardhat";
@@ -29,10 +30,13 @@ describe("ERC721AntiScam", function () {
 
   describe("setApprovalForAll", () => {
     it("指定レベルの認可対象は成功すること", async () => {
-      const { testNFT, account } = await loadFixture(fixture)
+      const { testNFT, owner, account } = await loadFixture(fixture)
       await testNFT.connect(account).mint(1, { value: ethers.utils.parseEther("1") })
       await expect(testNFT.connect(account).setApprovalForAll(allowedAddressesLv0[0], true))
         .not.to.be.reverted
+
+      // TODO いまはエラーになる
+      // await expect(testNFT.connect(account)["safeTransferFrom(address,address,uint256)"](account.address, owner.address, 0)).not.to.be.reverted
     })
 
     it("全レベルの認可対象外は失敗すること", async () => {
@@ -56,5 +60,93 @@ describe("ERC721AntiScam", function () {
       await expect(testNFT.connect(account).setApprovalForAll(allowedAddressesLv1[0], true))
         .not.to.be.reverted
     })
+  })
+
+  describe("CALの設定と変更のテスト", () => {
+    it("ownerであればCALを後から変更できる", async () => {
+      const { testNFT, market, owner, account } = await loadFixture(fixture)
+
+      const NewTimelock = await ethers.getContractFactory("Timelock")
+      const newTimelock = await NewTimelock.deploy(2, [ethers.constants.AddressZero], [ethers.constants.AddressZero])
+      await newTimelock.deployed()
+
+      const NewContractAllowList = await ethers.getContractFactory("ContractAllowList")
+      // Contian owner for test
+      const newContractAllowList = await NewContractAllowList.deploy([newTimelock.address, owner.getAddress()])
+      await newContractAllowList.deployed()
+
+      const NewContractAllowListProxy = await ethers.getContractFactory("ContractAllowListProxy")
+      const newContractAllowListProxy = await NewContractAllowListProxy.deploy(newContractAllowList.address)
+      await newContractAllowListProxy.deployed()
+
+      // ownerはCALを設定できる
+      await expect(testNFT.connect(owner).setCAL(newContractAllowListProxy.address))
+        .not.to.be.reverted
+      let gotCAL = await testNFT.CAL()
+      await expect(gotCAL).to.equals(newContractAllowListProxy.address)
+
+      // owner以外はCALを設定できない
+      await expect(testNFT.connect(account).setCAL(newContractAllowListProxy.address)).to.be.revertedWith('Ownable: caller is not the owner')
+
+      // ownerは0x000...を設定できる
+      await expect(testNFT.connect(owner).setCAL("0x0000000000000000000000000000000000000000"))
+        .not.to.be.reverted
+      gotCAL = await testNFT.CAL()
+      await expect(gotCAL).to.equals("0x0000000000000000000000000000000000000000")
+
+    })
+
+    it("CALが0アドレスでもLocalだけで動く", async () => {
+      const { testNFT, market, owner, account } = await loadFixture(fixture)
+
+      // ownerは0x000...を設定できる
+      await expect(testNFT.connect(owner).setCAL("0x0000000000000000000000000000000000000000"))
+        .not.to.be.reverted
+
+      // LockStatusをUnlockに設定するとエラーにならず動く
+      await expect(testNFT.connect(owner).setContractLockStatus(1))
+        .not.to.be.reverted
+
+      await testNFT.connect(account).mint(1, { value: ethers.utils.parseEther("1") })
+      await expect(testNFT.connect(account).setApprovalForAll(allowedAddressesLv1[0], true))
+        .not.to.be.reverted
+
+
+      // LockStatusをCalLockに設定するとLocalAllowListに設定されていなければエラー
+      await expect(testNFT.connect(owner).setContractLockStatus(2))
+        .not.to.be.reverted
+
+      await testNFT.connect(account).mint(1, { value: ethers.utils.parseEther("1") })
+      await expect(testNFT.connect(account).setApprovalForAll(allowedAddressesLv0[0], true))
+        .to.be.revertedWith('Can not approve locked token')
+
+      // LockStatusをCalLockに設定するとLocalAllowListに設定されていればエラーにならず動く
+      await expect(testNFT.connect(owner).addLocalContractAllowList(allowedAddressesLv0[0]))
+        .not.to.be.reverted
+
+      await expect(testNFT.connect(account).setApprovalForAll(allowedAddressesLv0[0], true))
+        .not.to.be.reverted
+
+      // LockStatusがCalLockの状態でLocalAllowListから削除すると再びエラー
+      await expect(testNFT.connect(owner).removeLocalContractAllowList(allowedAddressesLv0[0]))
+        .not.to.be.reverted
+
+      await testNFT.connect(account).mint(1, { value: ethers.utils.parseEther("1") })
+      await expect(testNFT.connect(account).setApprovalForAll(allowedAddressesLv0[0], true))
+        .to.be.revertedWith('Can not approve locked token')
+
+      // AllLockに設定するとLocalAllowListに設定されていてもエラー
+      await expect(testNFT.connect(owner).setContractLockStatus(3))
+        .not.to.be.reverted
+      await expect(testNFT.connect(owner).addLocalContractAllowList(allowedAddressesLv0[0]))
+        .not.to.be.reverted
+
+      await testNFT.connect(account).mint(1, { value: ethers.utils.parseEther("1") })
+      await expect(testNFT.connect(account).setApprovalForAll(allowedAddressesLv0[0], true))
+        .to.be.revertedWith('Can not approve locked token')
+
+    })
+
+
   })
 })

--- a/mock/ERC721AntiScam.ts
+++ b/mock/ERC721AntiScam.ts
@@ -1,4 +1,3 @@
-import { addressToBuffer } from "@nomicfoundation/ethereumjs-evm/dist/opcodes";
 import { loadFixture, time, mine } from "@nomicfoundation/hardhat-network-helpers";
 import { expect } from "chai";
 import { ethers } from "hardhat";

--- a/mock/ERC721AntiScam.ts
+++ b/mock/ERC721AntiScam.ts
@@ -34,8 +34,7 @@ describe("ERC721AntiScam", function () {
       await expect(testNFT.connect(account).setApprovalForAll(allowedAddressesLv0[0], true))
         .not.to.be.reverted
 
-      // TODO いまはエラーになる
-      // await expect(testNFT.connect(account)["safeTransferFrom(address,address,uint256)"](account.address, owner.address, 0)).not.to.be.reverted
+      await expect(testNFT.connect(account)["safeTransferFrom(address,address,uint256)"](account.address, owner.address, 0)).not.to.be.reverted
     })
 
     it("全レベルの認可対象外は失敗すること", async () => {
@@ -58,6 +57,7 @@ describe("ERC721AntiScam", function () {
       await testNFT.connect(owner).setContractAllowListLevel(1);
       await expect(testNFT.connect(account).setApprovalForAll(allowedAddressesLv1[0], true))
         .not.to.be.reverted
+      await expect(testNFT.connect(account)["safeTransferFrom(address,address,uint256)"](account.address, owner.address, 0)).not.to.be.reverted
     })
   })
 
@@ -109,6 +109,7 @@ describe("ERC721AntiScam", function () {
       await testNFT.connect(account).mint(1, { value: ethers.utils.parseEther("1") })
       await expect(testNFT.connect(account).setApprovalForAll(allowedAddressesLv1[0], true))
         .not.to.be.reverted
+      await expect(testNFT.connect(account)["safeTransferFrom(address,address,uint256)"](account.address, owner.address, 0)).not.to.be.reverted
 
 
       // LockStatusをCalLockに設定するとLocalAllowListに設定されていなければエラー
@@ -123,8 +124,10 @@ describe("ERC721AntiScam", function () {
       await expect(testNFT.connect(owner).addLocalContractAllowList(allowedAddressesLv0[0]))
         .not.to.be.reverted
 
+      await testNFT.connect(account).mint(1, { value: ethers.utils.parseEther("1") })
       await expect(testNFT.connect(account).setApprovalForAll(allowedAddressesLv0[0], true))
         .not.to.be.reverted
+      await expect(testNFT.connect(account)["safeTransferFrom(address,address,uint256)"](account.address, owner.address, 2)).not.to.be.reverted
 
       // LockStatusがCalLockの状態でLocalAllowListから削除すると再びエラー
       await expect(testNFT.connect(owner).removeLocalContractAllowList(allowedAddressesLv0[0]))

--- a/mock/deploy.ts
+++ b/mock/deploy.ts
@@ -48,7 +48,11 @@ export const deploy = async (owner: Signer) => {
 
   await testNFT.connect(owner).setContractAllowListLevel(0)
 
-  return { calVoteToken, timelock, calGoverner, contractAllowList, contractAllowListProxy, testNFT }
+  const MarketDummy = await ethers.getContractFactory("MarketDummy")
+  const market = await MarketDummy.connect(owner).deploy()
+  await market.deployed()
+
+  return { calVoteToken, timelock, calGoverner, contractAllowList, contractAllowListProxy, testNFT, market }
 }
 
 export default deploy

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -14,7 +14,7 @@ async function main() {
   await calGoverner.deployed()
 
   const ContractAllowList = await ethers.getContractFactory("ContractAllowList")
-  const contractAllowList = await ContractAllowList.deploy(calGoverner.address)
+  const contractAllowList = await ContractAllowList.deploy([calGoverner.address])
   await contractAllowList.deployed()
 
   timelock.grantRole(await timelock.EXECUTOR_ROLE(), calGoverner.address)


### PR DESCRIPTION
ERC721AntiScamに次の修正を行いました。
・localAllowedAddressesを追加し、独自にコントラクトの許可が出来るようにしました。
・CALを後から差し替えれるようにしました。それに伴い、CALが空でも動作するようにしました。
・LockStatus.CalLockの場合に、tokenIdがLockされていなければ、tokenIdの持ち主がsafeTransferFrom出来るように修正しました。