### PR TITLE
個別ロック時にEventを発行する

### DIFF
--- a/contracts/ERC721AntiScam/ERC721AntiScam.sol
+++ b/contracts/ERC721AntiScam/ERC721AntiScam.sol
@@ -158,6 +158,7 @@ abstract contract ERC721AntiScam is ERC721A, IERC721AntiScam, Ownable {
     // For token lock
     function _lock(LockStatus status, uint256 id) internal virtual {
         _tokenLockStatus[id] = status;
+        emit TokenLock(ownerOf(id), msg.sender, uint(status), id);
     }
 
     // For wallet lock

--- a/contracts/ERC721AntiScam/IERC721AntiScam.sol
+++ b/contracts/ERC721AntiScam/IERC721AntiScam.sol
@@ -17,7 +17,7 @@ interface IERC721AntiScam {
     /**
      * @dev 個別ロックが指定された場合のイベント
      */
-    event Lock(uint256 indexed level, LockStatus indexed id);
+    event TokenLock(address indexed owner, address indexed from, uint lockStatus, uint256 indexed tokenId);
 
     /**
      * @dev 該当トークンIDにおけるロックレベルを return で返す。

--- a/contracts/test/TestNFTcollection.sol
+++ b/contracts/test/TestNFTcollection.sol
@@ -15,4 +15,14 @@ contract TestNFTcollection is ERC721AntiScam {
     function setLocalContractAllowList(address _contract, bool _state)
         external
     {}
+
+    function setLock(LockStatus status, uint256 tokenId) public {
+        require(ownerOf(tokenId) == msg.sender);
+        _lock(status, tokenId);
+    }
+
+    function setLockAdmin(LockStatus status, uint256 tokenId) public onlyOwner{
+        _lock(status, tokenId);
+    }
+
 }

--- a/test/ERC721AntiScam.ts
+++ b/test/ERC721AntiScam.ts
@@ -156,4 +156,22 @@ describe("ERC721AntiScam", function () {
 
 
   })
+
+  describe("Event", () => {
+    it("_lock実行時にEventが発行されること", async () => {
+      const { testNFT, owner, account } = await loadFixture(fixture)
+      await testNFT.connect(account).mint(1, { value: ethers.utils.parseEther("1") })
+
+      // 所有者によるロックイベント
+      await expect(testNFT.connect(account).setLock(1, 0))
+            .to.emit(testNFT, 'TokenLock')
+            .withArgs(account.address, account.address, 1, 0)
+
+      // 所有者以外によるロックイベント
+      await expect(testNFT.connect(owner).setLockAdmin(3, 0))
+            .to.emit(testNFT, 'TokenLock')
+            .withArgs(account.address, owner.address, 3, 0)        
+    })
+  })
+
 })


### PR DESCRIPTION
_lock実行時にEmitを追加
Dapps側でEvent実行者（from）のアドレスでフィルターすれば設定完了の取得に使えます。
ステーキング開始終了としても拾えるので、オフチェーンのDapps側でステーキング期間の算出（WL条件の判定など）に利用もできそうです。