### PR TITLE
Feature npm publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,20 @@
+name: Publish Package to npmjs
+on:
+  release:
+    types: [created]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      # Setup .npmrc file to publish to npm
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '16.x'
+          registry-url: 'https://registry.npmjs.org'
+          # Defaults to the user or organization that owns the workflow file
+          scope: '@octocat'
+      - run: npm ci
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,7 @@ jobs:
           # Defaults to the user or organization that owns the workflow file
           scope: '@octocat'
       - run: npm ci
+      - run: npm version from-git
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,10 @@ jobs:
           # Defaults to the user or organization that owns the workflow file
           scope: '@octocat'
       - run: npm ci
+      - name: git setting
+        run: |
+          git config --local user.email ${{ secrets.GIT_EMAIL }}
+          git config --local user.name ${{ secrets.GIT_NAME }}
       - run: npm version from-git
       - run: npm publish
         env:

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,4 @@
+.devcontainer
+.github
+scripts
+test

--- a/README.md
+++ b/README.md
@@ -1,15 +1,34 @@
 # ContractAllowList
+
 Pull requests are accepted from all web3 engineers!!
 
+# Usage
+
+```console
+npm i contract-allow-list
+```
+
+or
+
+
+```console
+yarn contract-allow-list
+```
+
 # Why
+
 We want to put in place a system to minimize the damage from NFT fraud.
 
 # How
-Only accept approve from a limited number of contract addresses.
+
+- Only accept approve from a limited number of contract addresses.
+- Lock token and prevent transfer.
 
 # Target Contracts
+
 contracts>libs>ContractAllowList.sol
 *icontracts>interface>iContractAllowList.sol
 
 # Use Sample
+
 contracts>TestNFTcollection.sol

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -44,10 +44,4 @@ if(process.env.ALCHEMY_KEY){
   }
 }
 
-if(process.env.ALCHEMY_KEY){
-  config.networks!.goerli = {
-    url: "https://eth-goerli.g.alchemy.com/v2/" + process.env.ALCHEMY_KEY,
-    accounts: [`${process.env.PRIVATE_KEY}`],
-  }
-}
 export default config;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "contract-allow-list",
-  "version": "1.1.2",
+  "version": "2.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "contract-allow-list",
-      "version": "1.1.2",
+      "version": "2.1.2",
       "devDependencies": {
         "@nomicfoundation/hardhat-chai-matchers": "^1.0.3",
         "@nomicfoundation/hardhat-network-helpers": "^1.0.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "contract-allow-list",
-  "version": "1.0.0",
+  "version": "1.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "contract-allow-list",
-      "version": "1.0.0",
+      "version": "1.1.2",
       "devDependencies": {
         "@nomicfoundation/hardhat-chai-matchers": "^1.0.3",
         "@nomicfoundation/hardhat-network-helpers": "^1.0.6",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "name": "contract-allow-list",
   "version": "1.0.0",
-  "description": "transferを許可するコントラクトを管理する",
+  "description": "Project to protect NFT holders from scam.",
+  "license": "MIT",
   "scripts": {
     "test": "REPORT_GAS=true npx hardhat test"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contract-allow-list",
-  "version": "1.0.0",
+  "version": "1.1.2",
   "description": "Project to protect NFT holders from scam.",
   "license": "MIT",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contract-allow-list",
-  "version": "1.1.2",
+  "version": "2.1.2",
   "description": "Project to protect NFT holders from scam.",
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
tag作成時にnpm publishし、ERC721AntiScamやIContractAllowListをnpmで取得できるようにしました。

タグ名はセマンティックバージョニングに従う必要があります。例：1.0.0

GitHub Actionsでpublishさせるためには以下をRepositoryのsecretに追加してください。

- NPM_TOKEN : npmのトークンです。publish権限付のものをセットしてください。
- GIT_EMAIL : githubのメールアドレスです。
- GIT_NAME : gitに表示されるユーザー名です。

※GITの二つは正直ダミーでも構いません。