### PR TITLE
独自の許可アドレスの一覧を取得する機能を追加

### DIFF
--- a/contracts/ERC721AntiScam/restrictApprove/ERC721RestrictApprove.sol
+++ b/contracts/ERC721AntiScam/restrictApprove/ERC721RestrictApprove.sol
@@ -56,6 +56,15 @@ abstract contract ERC721RestrictApprove is ERC721A, IERC721RestrictApprove {
         emit LocalCalRemoved(msg.sender, transferer);
     }
 
+    function _getLocalContractAllowList()
+        internal
+        virtual
+        view
+        returns(address[] memory)
+    {
+        return localAllowedAddresses.values();
+    }
+
     function _isLocalAllowed(address transferer)
         internal
         view

--- a/contracts/ERC721AntiScam/restrictApprove/IERC721RestrictApprove.sol
+++ b/contracts/ERC721AntiScam/restrictApprove/IERC721RestrictApprove.sol
@@ -41,4 +41,9 @@ interface IERC721RestrictApprove {
      */
     function removeLocalContractAllowList(address transferer) external;
 
+    /**
+     * @dev CALのリストにある独自の許可アドレスの一覧を取得する。
+     */
+    function getLocalContractAllowList() external view returns(address[] memory);
+
 }

--- a/contracts/mock/TestNFTcollection.sol
+++ b/contracts/mock/TestNFTcollection.sol
@@ -64,6 +64,15 @@ contract TestNFTcollection is ERC721AntiScam, AccessControl {
         _removeLocalContractAllowList(transferer);
     }
 
+    function getLocalContractAllowList()
+        external
+        override
+        view
+        returns(address[] memory)
+    {
+        return _getLocalContractAllowList();
+    }
+
     function setCALLevel(uint256 level) external override onlyRole(ADMIN) {
         CALLevel = level;
     }

--- a/contracts/mock/extensions/MockERC721AntiScamControl.sol
+++ b/contracts/mock/extensions/MockERC721AntiScamControl.sol
@@ -37,6 +37,15 @@ contract MockERC721AntiScamControl is ERC721AntiScamControl {
         _removeLocalContractAllowList(transferer);
     }
 
+    function getLocalContractAllowList()
+        external
+        override
+        view
+        returns(address[] memory)
+    {
+        return _getLocalContractAllowList();
+    }
+    
     function setCALLevel(uint256 level) external override onlyOwner {
         CALLevel = level;
     }

--- a/test/ERC721AntiScam.ts
+++ b/test/ERC721AntiScam.ts
@@ -259,6 +259,42 @@ describe("ERC721AntiScam", function () {
         .not.to.be.reverted
       await expect(testNFT.connect(account)["safeTransferFrom(address,address,uint256)"](account.address, owner.address, 0)).not.to.be.reverted
     })
+
+    it("LocalCALの追加と削除", async () => {
+      const { testNFT, market, owner, account } = await loadFixture(fixture)
+      
+      expect((await testNFT.connect(owner).getLocalContractAllowList())[0]).to.equal(allowedAddressesLocal[0])
+
+      // 削除
+      expect(await testNFT.connect(owner).removeLocalContractAllowList(allowedAddressesLocal[0])).to.be.ok
+
+      expect((await testNFT.connect(account).getLocalContractAllowList()).length).to.equal(0)
+
+      await testNFT.connect(account).mint(1, { value: ethers.utils.parseEther("1") })
+      await expect(testNFT.connect(account).setApprovalForAll(allowedAddressesLocal[0], true))
+        .to.be.reverted
+
+      // 追加
+      expect(await testNFT.connect(owner).addLocalContractAllowList(allowedAddressesLocal[0])).to.be.ok
+
+      const allowedAddressesLocal2 = ethers.utils.getAddress('0x0dAE5FcaD0DF8E5C029D76927582DFBdFd7eeC79')
+
+      await expect(testNFT.connect(account).setApprovalForAll(allowedAddressesLocal2, true))
+        .to.be.reverted
+
+      expect(await testNFT.connect(owner).addLocalContractAllowList(allowedAddressesLocal2)).to.be.ok
+
+      await expect(testNFT.connect(account).setApprovalForAll(allowedAddressesLocal2, true))
+        .not.to.be.reverted
+      await expect(testNFT.connect(account)["safeTransferFrom(address,address,uint256)"](account.address, owner.address, 0)).not.to.be.reverted
+
+      const localContractAllowList = await testNFT.connect(account).getLocalContractAllowList()
+      expect(localContractAllowList.length).to.equal(2)
+      expect(localContractAllowList[0]).to.equal(allowedAddressesLocal[0])
+      expect(localContractAllowList[1]).to.equal(allowedAddressesLocal2)
+
+    })
+
   })
 
   describe("Event", () => {


### PR DESCRIPTION
他の関数に合わせる形で、独自の許可アドレスの一覧を取得する機能を追加しました。
また、それにあわせてテストも追加しました。

・IERC721RestrictApproveに関数を定義
・ERC721RestrictApproveにinternalの関数を実装
・TestNFTcollection及びMockERC721AntiScamControlで、IERC721RestrictApproveを実装し、内部でERC721RestrictApproveの関数を使用
