### PR TITLE
Burnableに変更

### DIFF
--- a/contracts/ERC721AntiScam/lockable/ERC721Lockable.sol
+++ b/contracts/ERC721AntiScam/lockable/ERC721Lockable.sol
@@ -2,12 +2,12 @@
 pragma solidity >=0.8.0;
 
 import "./IERC721Lockable.sol";
-import "erc721psi/contracts/ERC721Psi.sol";
+import "erc721psi/contracts/extension/ERC721PsiBurnable.sol";
 
 /// @title トークンのtransfer抑止機能付きコントラクト
 /// @dev Readmeを見てください。
 
-abstract contract ERC721Lockable is ERC721Psi, IERC721Lockable {
+abstract contract ERC721Lockable is ERC721PsiBurnable, IERC721Lockable {
     /*//////////////////////////////////////////////////////////////
     ロック変数。トークンごとに個別ロック設定を行う
     //////////////////////////////////////////////////////////////*/

--- a/contracts/ERC721AntiScam/restrictApprove/ERC721RestrictApprove.sol
+++ b/contracts/ERC721AntiScam/restrictApprove/ERC721RestrictApprove.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
 
-import "erc721psi/contracts/ERC721Psi.sol";
+import "erc721psi/contracts/extension/ERC721PsiBurnable.sol";
 import "./IERC721RestrictApprove.sol";
 import "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 import "../../proxy/interface/IContractAllowListProxy.sol";
@@ -9,7 +9,7 @@ import "../../proxy/interface/IContractAllowListProxy.sol";
 /// @title AntiScam機能付きERC721A
 /// @dev Readmeを見てください。
 
-abstract contract ERC721RestrictApprove is ERC721Psi, IERC721RestrictApprove {
+abstract contract ERC721RestrictApprove is ERC721PsiBurnable, IERC721RestrictApprove {
     using EnumerableSet for EnumerableSet.AddressSet;
 
     IContractAllowListProxy public CAL;


### PR DESCRIPTION
素のPsiだと_burnがなかったのでextensionのBurnableを利用するように変更しました。
現状、多くのNFTがBurnを実装しているので標準はBurnableにすべきと考えました。