### PR TITLE
20221129 bugfix pragma

### DIFF
--- a/contracts/ERC721AntiScam/lockable/ERC721Lockable.sol
+++ b/contracts/ERC721AntiScam/lockable/ERC721Lockable.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.0;
+pragma solidity >=0.8.8;
 
 import "./IERC721Lockable.sol";
 import "erc721psi/contracts/extension/ERC721PsiBurnable.sol";

--- a/contracts/ERC721AntiScam/lockable/IERC721Lockable.sol
+++ b/contracts/ERC721AntiScam/lockable/IERC721Lockable.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.0;
+pragma solidity >=0.8.8;
 
 /**
  * @title IERC721Lockable


### PR DESCRIPTION
ERC721Lockableがcompiler8.7以下でエラーになるため、8.8以上に変更。