### PR TITLE
CALcoreのlevel仕組みを変更

### DIFF
--- a/contracts/core/ContractAllowList.sol
+++ b/contracts/core/ContractAllowList.sol
@@ -101,11 +101,14 @@ contract ContractAllowList is IContractAllowList, AccessControlEnumerable {
         }
 
         bool Allowed = false;
-        for(uint256 i = 1; i < _level + 1; i++){
-            if(allowedAddresses[i].contains(_transferer) == true){
-                Allowed = true;
-                break;
-            }
+        // for(uint256 i = 1; i < _level + 1; i++){
+        //     if(allowedAddresses[i].contains(_transferer) == true){
+        //         Allowed = true;
+        //         break;
+        //     }
+        // }
+        if(allowedAddresses[_level].contains(_transferer) == true){
+            Allowed = true;
         }
         return Allowed;
     }


### PR DESCRIPTION
CALLevelの仕様をlevelごとに指定できるように変更

## このような運用とする
・Level1：今まで通りOpenSeaのみ
・Level2：クリエイターフィーが発生するマケプレのみ（現時点ではMagicEdenのみ）
・Level3：有名どころは全部OKにする、今のところはOpenSea、Blur、x2y2、looksrare、rarible、MagicEden。要望があれば追加していく